### PR TITLE
splitting out stag and prod configs

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -8,15 +8,44 @@ global:
 templates:
 - '/etc/alertmanager/template/*.tmpl'
 route:
+  # The labels by which incoming alerts are grouped together. For example,
+  # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+  # be batched into a single group.
   group_by: ['alertname', 'cluster', 'service']
+
+  # When a new group of alerts is created by an incoming alert, wait at
+  # least 'group_wait' to send the initial notification.
+  # This way ensures that you get multiple alerts for the same group that start
+  # firing shortly after another are batched together on the first 
+  # notification.
   group_wait: 30s
+
+  # When the first notification was sent, wait 'group_interval' to send a batch
+  # of new alerts that started firing for that group.
   group_interval: 5m
+
+  # If an alert has successfully been sent, wait 'repeat_interval' to
+  # resend them.
   repeat_interval: 1h
-  receiver: pagerduty
+
+  # A default receiver
+  receiver: pagerduty-warning
   routes:
   - match:
       alertname: DeadMansSwitch
     receiver: 'null'
+
+  # Match critical alerts, any alerts that do not match, 
+  # i.e. severity != critical, fall-back to the
+  # parent node and are sent to 'pagerduty-warning'
+  - match:
+      severity: critical
+    receiver: pagerduty-critical
+
+# Inhibition rules allow to mute a set of alerts given that another alert is
+# firing.
+# We use this to mute any warning-level notifications if the same alert is 
+# already critical.
 inhibit_rules:
 - source_match:
     severity: 'critical'
@@ -25,23 +54,10 @@ inhibit_rules:
   # Apply inhibition if the alertname is the same.
   equal: ['alertname', 'cluster', 'service']
 receivers:
-- name: 'pagerduty'
+- name: 'pagerduty-warning'
   pagerduty_configs:
   - service_key: c0b77df57db8474a983859a12f0b9901
-#  slack_configs:
-#  - channel: '#your_slack_channel'
-#   title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Prometheus Event Notification'
-#    text: >-
-#        {{ range .Alerts }}
-#           *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
-#          *Description:* {{ .Annotations.description }}
-#          *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:> *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>
-#          *Details:*
-#          {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
-#          {{ end }}
-#        {{ end }}
-#    send_resolved: true
-#  email_configs:
-#  - to: 'your_alert_email_address'
-#    send_resolved: true
+- name: 'pagerduty-critical'
+  pagerduty_configs:
+  - service_key: 401bcb421d9c4f5eb98adb6120fd13eb
 - name: 'null'

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -33,7 +33,7 @@ route:
   routes:
   - match:
       alertname: DeadMansSwitch
-    receiver: 'null'
+    receiver: deadmansswitch
 
   # Match critical alerts, any alerts that do not match, 
   # i.e. severity != critical, fall-back to the
@@ -60,4 +60,7 @@ receivers:
 - name: 'pagerduty-critical'
   pagerduty_configs:
   - service_key: 401bcb421d9c4f5eb98adb6120fd13eb
-- name: 'null'
+#- name: 'null'
+- name: deadmansswitch
+  webhook_configs:
+  - url: https://nosnch.in/d9eb65ee18?m=just+checking+in

--- a/assets/prometheus/rules/kubelet.rules
+++ b/assets/prometheus/rules/kubelet.rules
@@ -5,7 +5,7 @@ groups:
     expr: kube_node_status_condition{condition="Ready",status="true"} == 0
     for: 1h
     labels:
-      severity: warning
+      severity: critical
     annotations:
       description: The Kubelet on {{ $labels.node }} has not checked in with the API,
         or has set itself to NotReady, for more than an hour

--- a/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -364,7 +364,7 @@ data:
         expr: kube_node_status_condition{condition="Ready",status="true"} == 0
         for: 1h
         labels:
-          severity: warning
+          severity: critical
         annotations:
           description: The Kubelet on {{ $labels.node }} has not checked in with the API,
             or has set itself to NotReady, for more than an hour


### PR DESCRIPTION
@tsturzl https://www.pivotaltracker.com/story/show/155221433

* [Prometheus Critical](https://metismachine.pagerduty.com/services/PD92XOH/integrations) integrating with #alerts-critical
* [Prometheus Warning](https://metismachine.pagerduty.com/services/PJPZ0ST/integrations) integrates with #alerts-warning
* I went through everything in `/assets/prometheus/rules/` and changed `K8SNodeNotReady` to critical.  We can tweak severities as we go and add alerts as we go.
* This is probably a good first pass considering it will at least filter alerts by warning vs. critical but without considering the environment. The next step may be to:

1. break out the /assets/prometheus/rules/ by environment, e.g.:

```
- match:
  env: staging
receiver: pagerduty-warning
```

But this will require that we label all k8s components with the `env` label.

2. Give the PagerDuty alerts better Summaries, instead of something like `[FIRING:2] JobCompletion kube-state-metrics (http-metrics 100.127.192.6:8080 default kube-state-metrics-1882262178-psd1h warning)`.  According to Prometheus docs, that's defined in the alertmanager.yaml and the default is `[ description: <tmpl_string> | default = '{{ template "pagerduty.default.description" .}}' ]`