### PR TITLE
increasing threshold from 1s to 2s

### DIFF
--- a/assets/prometheus/rules/kube-apiserver.rules
+++ b/assets/prometheus/rules/kube-apiserver.rules
@@ -12,7 +12,7 @@ groups:
       summary: API server unreachable
   - alert: K8SApiServerLatency
     expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY"})
-      WITHOUT (instance, resource)) / 1e+06 > 1
+      WITHOUT (instance, resource)) / 1e+06 > 2
     for: 10m
     labels:
       severity: warning

--- a/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -260,7 +260,7 @@ data:
           summary: API server unreachable
       - alert: K8SApiServerLatency
         expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY"})
-          WITHOUT (instance, resource)) / 1e+06 > 1
+          WITHOUT (instance, resource)) / 1e+06 > 2
         for: 10m
         labels:
           severity: warning


### PR DESCRIPTION
@tsturzl https://www.pivotaltracker.com/story/show/155973155

Increasing the threshold from 1s to 2s, which cleared the alarm in staging (only happening in staging).  It's the:

```
histogram_quantile(0.99, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY"})
      WITHOUT (instance, resource)) / 1e+06 > 2
```

`{endpoint="https",job="apiserver",namespace="default",service="kubernetes",subresource="",verb="DELETECOLLECTION"}` is what takes longer than 1s.  I believe this is the job that cleans up the old github-user cronjobs.